### PR TITLE
fix: Fix gcc compilation by not sharing the same name between types and variables

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -1,11 +1,11 @@
-#include "background.hpp"
+#include "Background.hpp"
 #include "game.hpp"
 #include "time.hpp"
 #include <algorithm>
 #include <cstdlib>
 #include <ncurses.h>
 
-background::background()
+Background::Background()
     : spawn_cooldown(0),
       move_cooldown(0)
 {
@@ -14,7 +14,7 @@ background::background()
 	}
 }
 
-void background::update()
+void Background::update()
 {
 	// Spawn
 	if (get_current_time() - spawn_cooldown > 100) {
@@ -33,9 +33,9 @@ void background::update()
 	}
 }
 
-void background::spawn(int x)
+void Background::spawn(int x)
 {
-	background_entity bg = {};
+	BackgroundEntity bg = {};
 	bg.pattern = {{-1, 0}};
 	bg.current_pos.x = x;
 	bg.current_pos.y = rand() % map_height;
@@ -44,7 +44,7 @@ void background::spawn(int x)
 	entities.push_back(bg);
 }
 
-void background::print(WINDOW* game_win)
+void Background::print(WINDOW* game_win)
 {
 	for (auto& bg : entities) {
 		mvwaddwstr(
@@ -52,11 +52,11 @@ void background::print(WINDOW* game_win)
 	}
 }
 
-void background::prune()
+void Background::prune()
 {
 	entities.erase(std::remove_if(entities.begin(),
 	                              entities.end(),
-	                              [](background_entity& bg) {
+	                              [](BackgroundEntity& bg) {
 		                              return bg.current_pos.x < 0;
 	                              }),
 	               entities.end());

--- a/src/Background.hpp
+++ b/src/Background.hpp
@@ -1,27 +1,27 @@
 #pragma once
 
-#include "coordinate.hpp"
+#include "Coordinate.hpp"
 #include <cstddef>
 #include <ncurses.h>
 #include <vector>
 
-struct background_entity 
+struct BackgroundEntity 
 {
 	const wchar_t* ch;
-	coordinate current_pos;
-	std::vector<coordinate> pattern;
+	Coordinate current_pos;
+	std::vector<Coordinate> pattern;
 	size_t pattern_idx;
 };
 
-struct background 
+struct Background 
 {
-	background();
+	Background();
 	void update();
 	void spawn(int x);
 	void print(WINDOW* game_win);
     void prune();
 
-	std::vector<background_entity> entities;
+	std::vector<BackgroundEntity> entities;
 	std::vector<const wchar_t*> charset = {L"𖥔", L"✦", L"˖", L".", L" ݁ "};
 	long spawn_cooldown;
 	long move_cooldown;

--- a/src/Coordinate.hpp
+++ b/src/Coordinate.hpp
@@ -1,32 +1,32 @@
 #pragma once
 
-struct coordinate {
+struct Coordinate {
 	int x;
 	int y;
 
-	bool operator==(const coordinate& other)
+	bool operator==(const Coordinate& other)
 	{
 		return x == other.x && y == other.y;
 	}
 
-	coordinate operator+(const coordinate& other) const
+	Coordinate operator+(const Coordinate& other) const
 	{
 		return {x + other.x, y + other.y};
 	}
 
-	coordinate operator-(const coordinate& other) const
+	Coordinate operator-(const Coordinate& other) const
 	{
 		return {x - other.x, y - other.y};
 	}
 
-	coordinate& operator+=(const coordinate& other)
+	Coordinate& operator+=(const Coordinate& other)
 	{
 		x += other.x;
 		y += other.y;
 		return *this;
 	}
 
-	coordinate& operator-=(const coordinate& other)
+	Coordinate& operator-=(const Coordinate& other)
 	{
 		x -= other.x;
 		y -= other.y;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1,7 +1,7 @@
 #include "game.hpp"
 #include <ncurses.h>
 
-game::game()
+Game::Game()
 {
 	getmaxyx(stdscr, term_height, term_width);
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2,10 +2,10 @@
 #include "time.hpp"
 #include <ncurses.h>
 
-int player::created_players = 0;
+int Player::created_players = 0;
 
-player::player(coordinate position)
-    : entity(),
+Player::Player(Coordinate position)
+    : Entity(),
       appearance(appearances.at(created_players)),
       control_set{controls_sets.at(created_players)}
 {
@@ -15,7 +15,7 @@ player::player(coordinate position)
 	++created_players;
 }
 
-bool player::update(int input, game* game)
+bool Player::update(int input, Game* game)
 {
 	if (!status) {
 		return false;
@@ -41,7 +41,7 @@ bool player::update(int input, game* game)
 	return true;
 }
 
-void player::shoot(game* game)
+void Player::shoot(Game* game)
 {
 	if (!status) {
 		return;
@@ -49,7 +49,7 @@ void player::shoot(game* game)
 	if (get_current_time() - shoot_cooldown > 200) {
 		shoot_cooldown = get_current_time();
 
-		entity bullet = {};
+		Entity bullet = {};
 		bullet.type = PLAYER_BULLET;
 		bullet.status = true;
 		bullet.damage = 1;
@@ -59,7 +59,7 @@ void player::shoot(game* game)
 	}
 }
 
-bool player::on_collision(entity* entity)
+bool Player::on_collision(Entity* entity)
 {
 	if (status == false
 	    || !((current_pos == entity->current_pos)
@@ -84,7 +84,7 @@ bool player::on_collision(entity* entity)
 	return true;
 }
 
-void player::print(WINDOW* game_win)
+void Player::print(WINDOW* game_win)
 {
 	if (status) {
 		mvwaddwstr(game_win, current_pos.y + 1, current_pos.x * 2 + 2, appearance);

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "background.hpp"
-#include "coordinate.hpp"
+#include "Background.hpp"
+#include "Coordinate.hpp"
 #include <array>
 #include <ncurses.h>
 #include <stdlib.h>
@@ -53,7 +53,7 @@ inline const wchar_t  *game_over[] = {
 	L"                                        "
 };
 
-enum entity_type
+enum EntityType
 {
 	PLAYER,
 	BASIC_ENEMY,
@@ -67,9 +67,9 @@ enum entity_type
 	BOSS,
 };
 
-struct game;
+struct Game;
 
-struct window
+struct Window
 {
 	WINDOW	*win;
 	int		height;
@@ -78,7 +78,7 @@ struct window
 	int		pos_x;
 };
 
-struct entity
+struct Entity
 {
 	int		id;
 	int		type;
@@ -92,13 +92,13 @@ struct entity
 	long		shoot_cooldown;
 	long		move_cooldown;
 	//long		spawn_cooldown;
-	std::vector<coordinate>	pattern;
+	std::vector<Coordinate>	pattern;
 	size_t		pattern_idx;
-	coordinate	previous_pos;
-	coordinate	current_pos;
+	Coordinate	previous_pos;
+	Coordinate	current_pos;
 };
 
-struct player : public entity 
+struct Player : public Entity 
 {
 	constexpr static int max_players = 2;
 	constexpr static std::array<std::array<int, 5>, max_players> controls_sets = 
@@ -109,24 +109,24 @@ struct player : public entity
 		  {L"🚀"}}};
 	static int created_players;
 
-	player(coordinate position);
-	bool update(int input, game *game);
-	void shoot(game *game);
-	bool on_collision(entity *entity);
+	Player(Coordinate position);
+	bool update(int input, Game *game);
+	void shoot(Game *game);
+	bool on_collision(Entity *entity);
 	void print(WINDOW *game_win);
 	
 	const wchar_t *appearance;
 	std::array<int, 5> control_set;
 };
 
-// struct enemy : public entity
+// struct enemy : public Entity
 // {
 
 // };
 
-struct game
+struct Game
 {
-	game();
+	Game();
 
 	WINDOW	*game_win;
 	WINDOW	*status_win;
@@ -136,25 +136,25 @@ struct game
 	int		game_width;
 	int		status_height;
 	int		status_width;
-	std::vector<player> players;
+	std::vector<Player> players;
 	long	score;
 	long	time;
 	long	enemy_spawn_cooldown;
 	int		boss_health;
 	bool	boss_status;
 	long	spawn_boss_cooldown;
-	//entity	bullets[MAX_BULLETS];
-	/* window	game_win;
-	window	status_win;
-	entity	player;*/
-	std::vector<entity>	enemies;
-	std::vector<entity>	bullets;
-	std::vector<entity>	collidables;
-	background	background;
+	//Entity	bullets[MAX_BULLETS];
+	/* Window	game_win;
+	Window	status_win;
+	Entity	player;*/
+	std::vector<Entity>	enemies;
+	std::vector<Entity>	bullets;
+	std::vector<Entity>	collidables;
+	Background	background;
 };
 
-int shared_players_hp(game *game);
-game *get_game(void);
+int shared_players_hp(Game *game);
+Game *get_game(void);
 
 //background
 //collidables

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,9 +14,9 @@
 int map_width;
 int map_height;
 
-game *get_game(void)
+Game *get_game(void)
 {
-	static game game{};
+	static Game game{};
 
 	return (&game);
 }
@@ -51,7 +51,7 @@ WINDOW *create_win(int size_y, int size_x , int pos_y, int pox_x)
 
 void	init_win()
 {
-	game *game = get_game();
+	Game *game = get_game();
 	game->game_win = create_win(game->game_height, game->game_width, GAME_WINDOW_Y, GAME_WINDOW_X);
 	game->status_win = create_win(game->status_height, game->status_width, STATUS_WINDOW_Y, STATUS_WINDOW_X);
 	wrefresh(game->game_win);
@@ -60,12 +60,12 @@ void	init_win()
 
 void delete_win()
 {
-	game *game = get_game();
+	Game *game = get_game();
 	delwin(game->game_win);
 	delwin(game->status_win);
 }
 
-int shared_players_hp(game *game)
+int shared_players_hp(Game *game)
 {
 	int shared_hp = 0;
 	for (auto& player : game->players) {
@@ -74,7 +74,7 @@ int shared_players_hp(game *game)
 	return shared_hp;
 }
 
-void	print_status(game *game)
+void	print_status(Game *game)
 {
 	for (int j = 0; j < game->status_height; j++)
 	{
@@ -96,7 +96,7 @@ void	print_status(game *game)
 	wrefresh(game->status_win);
 }
 
-bool	is_bullet(game *game, int y, int x, int type)
+bool	is_bullet(Game *game, int y, int x, int type)
 {
 	for (size_t i = 0; i < game->bullets.size(); i++)
 	{
@@ -108,7 +108,7 @@ bool	is_bullet(game *game, int y, int x, int type)
 	return (false);
 }
 
-bool	is_enemy(game *game, int y, int x, int type)
+bool	is_enemy(Game *game, int y, int x, int type)
 {
 	for (size_t i = 0; i < game->enemies.size(); i++)
 	{
@@ -125,7 +125,7 @@ bool	is_enemy(game *game, int y, int x, int type)
 
 } */
 
-void print_gameover(game *game)
+void print_gameover(Game *game)
 {
 	const size_t game_over_height = sizeof(game_over) / sizeof(game_over[0]);
 	const size_t game_over_width = 40;
@@ -137,7 +137,7 @@ void print_gameover(game *game)
 	}
 }
 
-void	print_game(game *game)
+void	print_game(Game *game)
 {
 	// Clear window
 	for (int y = 0; y < game->game_height; y++)
@@ -218,19 +218,19 @@ void	print_game(game *game)
 
 void	print_stuff()
 {
-	game *game = get_game();
+	Game *game = get_game();
 
 	print_game(game);
 	print_status(game);
 	//refresh();
 }
 
-void	spawn_enemy_bullet(game *game, entity *enemy, int bullet_type, int source)
+void	spawn_enemy_bullet(Game *game, Entity *enemy, int bullet_type, int source)
 {
 	enemy->shoot_cooldown = get_current_time();
 	if (enemy->type != BOSS && rand() % 2 == 0)
 		return ;
-	entity bullet = {};
+	Entity bullet = {};
 	bullet.type = bullet_type;
 	bullet.source = source;
 	bullet.status = 1;
@@ -241,17 +241,17 @@ void	spawn_enemy_bullet(game *game, entity *enemy, int bullet_type, int source)
 	game->bullets.push_back(bullet);
 }
 
-void	move_p_bullet(entity *bullet)
+void	move_p_bullet(Entity *bullet)
 {
 	bullet->move_cooldown = get_current_time();
 	bullet->previous_pos = bullet->current_pos;
 	bullet->current_pos.x++;
 }
 
-std::optional<player *> find_nearest_player_in_x(game *game, entity *entity)
+std::optional<Player *> find_nearest_player_in_x(Game *game, Entity *entity)
 {
 	int min_distance_y = INT_MAX;
-	std::optional<player *> nearest_player = std::nullopt;
+	std::optional<Player *> nearest_player = std::nullopt;
 
 	for (auto& player : game->players) {
 		if (player.current_pos.x != entity->current_pos.x) {
@@ -266,7 +266,7 @@ std::optional<player *> find_nearest_player_in_x(game *game, entity *entity)
 	return nearest_player;
 }
 
-void	move_enemy_bullets(game *game, entity *bullet)
+void	move_enemy_bullets(Game *game, Entity *bullet)
 {
 	bullet->move_cooldown = get_current_time();
 	bullet->previous_pos = bullet->current_pos;
@@ -288,7 +288,7 @@ void	move_enemy_bullets(game *game, entity *bullet)
 		bullet->current_pos.x--;
 }
 
-void	move_enemy(entity *enemy)
+void	move_enemy(Entity *enemy)
 {
 	enemy->move_cooldown = get_current_time();
 	if (enemy->pattern_idx >= enemy->pattern.size())
@@ -299,7 +299,7 @@ void	move_enemy(entity *enemy)
 	enemy->pattern_idx++;
 }
 
-void	update_entities(game *game)
+void	update_entities(Game *game)
 {
 	for (size_t i = 0; i < game->bullets.size(); i++)
 	{
@@ -347,9 +347,9 @@ void	update_entities(game *game)
 	}
 }
 
-void	spawn_basic_enemy(game *game, int y, int x)
+void	spawn_basic_enemy(Game *game, int y, int x)
 {
-	entity enemy = {};
+	Entity enemy = {};
 	enemy.status = 1;
 	enemy.type = BASIC_ENEMY;
 	enemy.current_pos.y = y;
@@ -362,9 +362,9 @@ void	spawn_basic_enemy(game *game, int y, int x)
 	game->enemies.push_back(enemy);
 }
 
-void	spawn_enemy_1(game *game, int y, int x)
+void	spawn_enemy_1(Game *game, int y, int x)
 {
-	entity enemy = {};
+	Entity enemy = {};
 	enemy.status = 1;
 	enemy.type = ENEMY_1;
 	enemy.current_pos.y = y;
@@ -377,9 +377,9 @@ void	spawn_enemy_1(game *game, int y, int x)
 	game->enemies.push_back(enemy);
 }
 
-void	spawn_enemy_2(game *game, int y, int x)
+void	spawn_enemy_2(Game *game, int y, int x)
 {
-	entity enemy = {};
+	Entity enemy = {};
 	enemy.status = 1;
 	enemy.type = ENEMY_2;
 	enemy.current_pos.y = y;
@@ -392,9 +392,9 @@ void	spawn_enemy_2(game *game, int y, int x)
 	game->enemies.push_back(enemy);
 }
 
-void	spawn_boss(game *game, int y, int x, int id)
+void	spawn_boss(Game *game, int y, int x, int id)
 {
-	entity enemy = {};
+	Entity enemy = {};
 	enemy.status = 1;
 	enemy.id = id;
 	enemy.type = BOSS;
@@ -410,7 +410,7 @@ void	spawn_boss(game *game, int y, int x, int id)
 	game->enemies.push_back(enemy);
 }
 
-void	spawn_entities(game *game)
+void	spawn_entities(Game *game)
 {
 	static int i = 1;
 	if (!(get_current_time() - game->enemy_spawn_cooldown > 4000))
@@ -454,7 +454,7 @@ void	spawn_entities(game *game)
 	}
 }
 
-void	check_bullet_collision(game *game, entity *entity, int type)
+void	check_bullet_collision(Game *game, Entity *entity, int type)
 {
 	for (size_t i = 0; i < game->bullets.size(); i++)
 	{
@@ -469,7 +469,7 @@ void	check_bullet_collision(game *game, entity *entity, int type)
 	}
 }
 
-void kill_boss(game *game)
+void kill_boss(Game *game)
 {
 	for (size_t i = 0; i < game->enemies.size(); i++)
 	{
@@ -479,7 +479,7 @@ void kill_boss(game *game)
 	}
 }
 
-void	check_enemy_collision(game *game, entity *entity, int type)
+void	check_enemy_collision(Game *game, Entity *entity, int type)
 {
 	for (size_t i = 0; i < game->enemies.size(); i++)
 	{
@@ -511,7 +511,7 @@ void	check_enemy_collision(game *game, entity *entity, int type)
 	}
 }
 
-void	check_collisions(game *game)
+void	check_collisions(Game *game)
 {
 	for (size_t i = 0; i < game->bullets.size(); i++)
 	{
@@ -546,34 +546,34 @@ void	check_collisions(game *game)
 	}
 }
 
-void	prune_inactive(game *game_)
+void	prune_inactive(Game *game)
 {
-	game_->bullets.erase(
-		std::remove_if(game_->bullets.begin(), game_->bullets.end(), 
-			[](entity& object){ 
+	game->bullets.erase(
+		std::remove_if(game->bullets.begin(), game->bullets.end(), 
+			[](Entity& object){ 
 				if (object.status == false || object.current_pos.y < 0 || object.current_pos.x < 0 || object.current_pos.y >=   map_height || object.current_pos.x >= map_width)
 					return (true);
 				else
 					return (false);
 			}), 
-		game_->bullets.end());
+		game->bullets.end());
 
-	game_->enemies.erase(
-		std::remove_if(game_->enemies.begin(), game_->enemies.end(), 
-			[](entity& object){ 
+	game->enemies.erase(
+		std::remove_if(game->enemies.begin(), game->enemies.end(), 
+			[](Entity& object){ 
 				if (object.status == false || object.current_pos.y < 0 || object.current_pos.x < 0 || object.current_pos.y >=   map_height || object.current_pos.x >= map_width)
 					return (true);
 				else
 					return (false);
 			}), 
-		game_->enemies.end());
+		game->enemies.end());
 
-	game_->background.prune();
+	game->background.prune();
 }
 
 bool	check_terminal_size()
 {
-	game *game = get_game();
+	Game *game = get_game();
 	int y;
 	int x;
 
@@ -598,7 +598,7 @@ bool	check_terminal_size()
 
 bool	game_loop()
 {
-	game *game = get_game();
+	Game *game = get_game();
 	long	time_reference = get_current_time();
 	game->time = get_current_time_in_seconds();
 	nodelay(stdscr, TRUE);
@@ -656,8 +656,8 @@ bool	game_loop()
 
 void	init_players(int amount)
 {
-	game *game = get_game();
-	coordinate start = {(map_width / 2) - 3,  map_height / 2};
+	Game *game = get_game();
+	Coordinate start = {(map_width / 2) - 3,  map_height / 2};
 	const int spacing = 4;
 
 	start.y -= (spacing / 2) * (amount - 1);
@@ -681,7 +681,7 @@ void set_map_size()
 
 int	menu()
 {
-	//game *game = get_game();
+	//Game *game = get_game();
 	int i = 1;
 	while (1)
 	{


### PR DESCRIPTION
gcc didn't let it compile with our set of compilation flags. On campus the default compiler is clang and it is more permissive, that's why it worked.

Usually, types (i.e. structs and classes) are written in PascalCase while variables use snake_case or camelCase.
Or, like the 42 Norm, prefixes or suffixes are used (`s_*` for structs, `t_*` for typedefs, `e_*` for enums, etc).