### PR TITLE
feat: Add restart option (`R` key) when gameover 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The project was made in a setting which we at 42 Vienna call a *Rush* - we rando
 - Player 2
   - `Arrow keys`: Move your ship
   - `Enter`: Shoot
+- `R`: Restart when gameover
 - `Q` | `Esc`: Quit game
 
 ---

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -59,7 +59,7 @@ void Player::shoot(Game* game)
 	}
 }
 
-bool Player::on_collision(Entity* entity)
+bool Player::on_collision(Entity* entity, Game *game)
 {
 	if (status == false
 	    || !((current_pos == entity->current_pos)
@@ -78,7 +78,7 @@ bool Player::on_collision(Entity* entity)
 	else if (entity->type != BOSS) {
 		entity->status = false;
 	}
-	if (shared_players_hp(get_game()) <= 0) {
+	if (shared_players_hp(game) <= 0) {
 		status = false;
 	}
 	return true;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2,17 +2,15 @@
 #include "time.hpp"
 #include <ncurses.h>
 
-int Player::created_players = 0;
-
-Player::Player(Coordinate position)
+Player::Player(int id, Coordinate position)
     : Entity(),
-      appearance(appearances.at(created_players)),
-      control_set{controls_sets.at(created_players)}
+      appearance(appearances.at(id)),
+      control_set{controls_sets.at(id)}
 {
+	this->id = id;
 	current_pos = position;
 	status = true;
 	hp = 3;
-	++created_players;
 }
 
 bool Player::update(int input, Game* game)

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -118,7 +118,7 @@ struct Player : public Entity
 	Player(Coordinate position);
 	bool update(int input, Game *game);
 	void shoot(Game *game);
-	bool on_collision(Entity *entity);
+	bool on_collision(Entity *entity, Game *game);
 	void print(WINDOW *game_win);
 	
 	const wchar_t *appearance;
@@ -134,8 +134,8 @@ struct Game
 {
 	Game();
 
-	WINDOW	*game_win;
-	WINDOW	*status_win;
+	WINDOW	*game_win = NULL;
+	WINDOW	*status_win = NULL;
 	int		term_height;
 	int		term_width;
 	int		game_height;
@@ -143,13 +143,13 @@ struct Game
 	int		status_height;
 	int		status_width;
 	std::vector<Player> players;
-	long	score;
-	long	start_time;
-	long	gameover_time;
-	long	enemy_spawn_cooldown;
-	int		boss_health;
-	bool	boss_status;
-	long	spawn_boss_cooldown;
+	long	score = 0;
+	long	start_time = 0;
+	long	gameover_time = 0;
+	long	enemy_spawn_cooldown = 0;
+	int		boss_health = 0;
+	bool	boss_status = 0;
+	long	spawn_boss_cooldown = 0;
 	//Entity	bullets[MAX_BULLETS];
 	/* Window	game_win;
 	Window	status_win;
@@ -161,7 +161,6 @@ struct Game
 };
 
 int shared_players_hp(Game *game);
-Game *get_game(void);
 
 //background
 //collidables

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -113,9 +113,8 @@ struct Player : public Entity
 	constexpr static std::array<const wchar_t[2], max_players> appearances =
 		{{{L"🛸"},
 		  {L"🚀"}}};
-	static int created_players;
 
-	Player(Coordinate position);
+	Player(int id, Coordinate position);
 	bool update(int input, Game *game);
 	void shoot(Game *game);
 	bool on_collision(Entity *entity, Game *game);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@ void	init_win(Game *game)
 	game->status_win = create_win(game->status_height, game->status_width, STATUS_WINDOW_Y, STATUS_WINDOW_X);
 	wrefresh(game->game_win);
 	wrefresh(game->status_win);
+	clear();
 }
 
 void	delete_win(Game *game)
@@ -63,11 +64,13 @@ void	delete_win(Game *game)
 	{
 		delwin(game->game_win);
 		game->game_win = NULL;
+		clear();
 	}
 	if (game->status_win != NULL)
 	{
 		delwin(game->status_win);
 		game->status_win = NULL;
+		clear();
 	}
 }
 
@@ -750,7 +753,6 @@ try {
 		print_stuff(&game);
 		keep_playing = game_loop(&game);
 		delete_win(&game);
-		clear();
 	}
 	endwin();
 	return (0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,7 +434,8 @@ void	spawn_boss(Game *game, int y, int x, int id)
 void	spawn_entities(Game *game)
 {
 	static int i = 0;
-	if (!(get_current_time() - game->enemy_spawn_cooldown > 5000))
+	if (!(get_current_time() - game->enemy_spawn_cooldown > 5000)
+		|| shared_players_hp(game) == 0)
 		return ;
 	game->enemy_spawn_cooldown = get_current_time();
 	if (game->score >= 500 && get_current_time() - game->spawn_boss_cooldown > 25000 && game->boss_status == 0) //change values

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -739,7 +739,7 @@ int	menu()
 			return -1;
 		if (input == 'w' || input == KEY_UP || input == 's' || input == KEY_DOWN)
 			i *= -1;
-		if (input == '\n')
+		if (input == '\n' || input == ' ')
 		{
 			if (i == 1)
 				return (1);


### PR DESCRIPTION
The `R` key only works when gameover. It will prompt for the player amount again and adjust the map size to the terminal size, in case it was resized.
The previously selected menu option stays the first selected when getting into the menu again. So when previously multiplayer was selected, it is faster to play with multiplayer again.

---

**Also:**
- Stop spawning enemies when gameover
- Allow spacebar for menu confirmation
- Remove static game instance
- Fix text leftovers showing through when resizing terminal