### PR TITLE
refactor: Handle auto-fire in `Player`, disable auto-fire also with shoot key

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -18,8 +18,13 @@ bool Player::update(int input, Game* game)
 	if (!status) {
 		return false;
 	}
+
+	bool got_input = true;
 	if (input == control_set[0] && current_pos.y != 0) {
 		current_pos.y--;
+	}
+	else if (input == control_set[1] && current_pos.x != 0) {
+		current_pos.x--;
 	}
 	else if (input == control_set[2] && current_pos.y != map_height - 1) {
 		current_pos.y++;
@@ -27,16 +32,21 @@ bool Player::update(int input, Game* game)
 	else if (input == control_set[3] && current_pos.x != map_width - 1) {
 		current_pos.x++;
 	}
-	else if (input == control_set[1] && current_pos.x != 0) {
-		current_pos.x--;
-	}
 	else if (input == control_set[4]) {
+		auto_fire_toggle = false;
 		shoot(game);
 	}
-	else {
-		return false;
+	else if (input == control_set[5]) {
+		auto_fire_toggle = !auto_fire_toggle;
 	}
-	return true;
+	else {
+		got_input = false;
+	}
+
+	if (auto_fire_toggle) {
+		shoot(game);
+	}
+	return got_input;
 }
 
 void Player::shoot(Game* game)

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1,3 +1,4 @@
+#include "Coordinate.hpp"
 #include "game.hpp"
 #include "time.hpp"
 #include <ncurses.h>
@@ -67,9 +68,9 @@ void Player::shoot(Game* game)
 	}
 }
 
-bool Player::on_collision(Entity* entity, Game *game)
+bool Player::on_collision(Entity* entity, Game* game)
 {
-	if (status == false
+	if (!status
 	    || !((current_pos == entity->current_pos)
 	         || (current_pos == entity->previous_pos
 	             && previous_pos == entity->current_pos))) {
@@ -80,8 +81,9 @@ bool Player::on_collision(Entity* entity, Game *game)
 	    || entity->type == BOSS) {
 		invis_frames = get_current_time();
 		hp--;
-		if (entity->type != BOSS)
+		if (entity->type != BOSS) {
 			entity->status = false;
+		}
 	}
 	else if (entity->type != BOSS) {
 		entity->status = false;
@@ -95,11 +97,15 @@ bool Player::on_collision(Entity* entity, Game *game)
 void Player::print(WINDOW* game_win)
 {
 	if (status) {
-		if (!(get_current_time() - invis_frames < 1200 && (((get_current_time() - invis_frames) / 100) % 2 == 0))) {
-			mvwaddwstr(game_win, current_pos.y + 1, current_pos.x * 2 + 2, appearance);
+		if (get_current_time() - invis_frames >= 1200
+		    || (((get_current_time() - invis_frames) / 100) % 2 != 0)) {
+			mvwaddwstr(game_win,
+			           current_pos.y + 1,
+			           (current_pos.x * 2) + 2,
+			           appearance);
 		}
 	}
 	else {
-		mvwaddwstr(game_win, current_pos.y + 1, current_pos.x * 2 + 2, L"💥");
+		mvwaddwstr(game_win, current_pos.y + 1, (current_pos.x * 2) + 2, L"💥");
 	}
 }

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -123,7 +123,7 @@ struct Player : public Entity
 	
 	const wchar_t *appearance;
 	std::array<int, 6> control_set;
-	bool auto_fire_toggle;
+	bool auto_fire_toggle = false;
 };
 
 // struct enemy : public Entity

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -708,10 +708,6 @@ bool	game_loop(Game *game)
 			int input = tolower(getch());
 			if (input == 'q' || input == KEY_ESCAPE)
 				return false;
-			for (auto& player : game->players) {
-				if (input == player.control_set[5])
-					player.auto_fire_toggle = player.auto_fire_toggle == true ? false : true;
-			}
 			if (input == 'r' && shared_players_hp(game) <= 0)
 				return true;
 			if (input == KEY_RESIZE)
@@ -725,10 +721,6 @@ bool	game_loop(Game *game)
 					if (player.update(input, game)) {
 						break;
 					}
-				}
-				for (auto& player : game->players) {
-					if (player.auto_fire_toggle)
-						player.shoot(game);
 				}
 			}
 			update_entities(game);


### PR DESCRIPTION
Each object should handle its own data. This is called "Encapsulation" and is 1 of 4 core pillars of Object-Oriented Programming.
There are features in C++ (like `public` and `private` keywords) to enforce this much more, but I didn't want to introduce this during the Rush.
It is very useful to have everything `Player`-related in one place. It's like the `vector`: it has a bunch of useful functions that operate on the `vector` itself. They just work and we don't have to care how exactly it does it. That is what makes an object nice to work with and, most importantly, easy to maintain.

Let me know if you think disabling the auto-fire also with the shoot key is weird.

Changes to `Player::on_collision()` and `Player::print()` are only formatting.