### PR TITLE
fix: Fix alive player still being able to play when shared hp is 0

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -18,6 +18,9 @@ bool Player::update(int input, Game* game)
 	if (!status) {
 		return false;
 	}
+	if (shared_players_hp(game) <= 0) {
+		status = false;
+	}
 	if (input == control_set[0] && current_pos.y != 0) {
 		current_pos.y--;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -426,7 +426,7 @@ void	spawn_entities(Game *game)
 {
 	static int i = 0;
 	if (!(get_current_time() - game->enemy_spawn_cooldown > 5000)
-		|| shared_players_hp(game) == 0)
+		|| shared_players_hp(game) <= 0)
 		return ;
 	game->enemy_spawn_cooldown = get_current_time();
 	if (game->score >= 500 && get_current_time() - game->spawn_boss_cooldown > 25000 && game->boss_status == 0) //change values
@@ -651,9 +651,6 @@ bool	game_loop(Game *game)
 			game->background.update();
 			if (shared_players_hp(game) <= 0)
 			{
-				for (auto& player : game->players) {
-					mvwaddwstr(game->game_win, player.current_pos.y + 1, (player.current_pos.x * 2) + 2, L"💥");
-				}
 				if (game->gameover_time == 0) {
 					game->gameover_time = get_current_time_in_seconds();
 				}


### PR DESCRIPTION
Even though game over was printed, the player who didn't cause it was still able to move and shoot and even add to the score. It only died when it was also hit.

This bug existed since commit 5432f8b0505c3abc65521953faf089a34aff5ad0.